### PR TITLE
Integrate Firebase Crashlytics.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("com.google.devtools.ksp")
     id("com.google.dagger.hilt.android")
     id("com.google.gms.google-services")
+    id("com.google.firebase.crashlytics")
 }
 
 val keystoreProperties = Properties()
@@ -119,6 +120,11 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics-ktx")
     implementation("com.google.firebase:firebase-storage-ktx:20.2.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4")
+
+    // Crashlytics
+    implementation(platform("com.google.firebase:firebase-bom:32.3.1"))
+    implementation("com.google.firebase:firebase-crashlytics-ktx")
+    implementation("com.google.firebase:firebase-analytics-ktx")
 
     // Google Material
     implementation("com.google.android.material:material:1.9.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,4 +9,5 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.8.10" apply false
     id("com.google.devtools.ksp") version "1.8.10-1.0.9" apply false
     id("com.google.dagger.hilt.android") version "2.48" apply false
+    id("com.google.firebase.crashlytics") version "2.9.9" apply false
 }


### PR DESCRIPTION
Integrate Firebase Crashlytics to app so I can get info when app crashes to an user.

![Screenshot_36](https://github.com/diargegaj/Recipe-Sharing/assets/58120779/b2731176-a533-4839-ae33-f1f9fc0d9cc0)
